### PR TITLE
Straight package-manager integration

### DIFF
--- a/README.org
+++ b/README.org
@@ -325,14 +325,12 @@ Given a list, the arguments are passed as is to ~straight-use-package~.
 
       ((leaf leaf
          :init (leaf-pre-init)
-         :straight (zenburn-theme :type git :host github
-                                  :repo "fake/fake")
+         :straight (zenburn-theme :type git :host github :repo "fake/fake")
          :config (leaf-init))
        (prog1 'leaf
          (eval-after-load 'straight
            '(progn
-              (straight-use-package '(zenburn-theme :type git :host github
-                                                    :repo "fake/fake"))))
+              (straight-use-package '(zenburn-theme :type git :host github :repo "fake/fake"))))
          (leaf-pre-init)
          (leaf-init)))
 

--- a/README.org
+++ b/README.org
@@ -266,6 +266,93 @@ Given a list, the arguments are passed as is to the ~el-get-bundle~.
          (leaf-init)))))
 #+end_src
 
+** :straight keyword
+~:straight~ provides a frontend for ~straight-use-package~.
+
+If you specify ~t~, leaf assumes that you specified the name of the leaf-block.
+
+Given a list, the arguments are passed as is to ~straight-use-package~.
+
+#+begin_src elisp
+  (cort-deftest-with-macroexpand leaf/straight
+    '(((leaf leaf
+         :init (leaf-pre-init)
+         :straight t
+         :config (leaf-init))
+       (prog1 'leaf
+         (eval-after-load 'straight
+           '(progn
+              (straight-use-package 'leaf)))
+         (leaf-pre-init)
+         (leaf-init)))
+
+      ((leaf leaf
+         :init (leaf-pre-init)
+         :straight leaf leaf-polyfill
+         :config (leaf-init))
+       (prog1 'leaf
+         (eval-after-load 'straight
+           '(progn
+              (straight-use-package 'leaf)
+              (straight-use-package 'leaf-polyfill)))
+         (leaf-pre-init)
+         (leaf-init)))
+
+      ((leaf leaf
+         :init (leaf-pre-init)
+         :straight t
+         :straight leaf-polyfill
+         :config (leaf-init))
+       (prog1 'leaf
+         (eval-after-load 'straight
+           '(progn
+              (straight-use-package 'leaf)
+              (straight-use-package 'leaf-polyfill)))
+         (leaf-pre-init)
+         (leaf-init)))
+
+      ((leaf leaf
+         :init (leaf-pre-init)
+         :straight t leaf-polyfill
+         :config (leaf-init))
+       (prog1 'leaf
+         (eval-after-load 'straight
+           '(progn
+              (straight-use-package 'leaf)
+              (straight-use-package 'leaf-polyfill)))
+         (leaf-pre-init)
+         (leaf-init)))
+
+      ((leaf leaf
+         :init (leaf-pre-init)
+         :straight (zenburn-theme :type git :host github
+                                  :repo "fake/fake")
+         :config (leaf-init))
+       (prog1 'leaf
+         (eval-after-load 'straight
+           '(progn
+              (straight-use-package '(zenburn-theme :type git :host github
+                                                    :repo "fake/fake"))))
+         (leaf-pre-init)
+         (leaf-init)))
+
+      ((leaf leaf
+         :init (leaf-pre-init)
+         :straight
+         (zenburn-theme :type git :host github :repo "fake/fake")
+         (yaicomplete :type git :host github :repo "fake/faker")
+         (mew :type git :host gitlab :repo "fake/fakest" :no-build)
+         :config (leaf-init))
+       (prog1 'leaf
+         (eval-after-load 'straight
+           '(progn
+              (straight-use-package '(zenburn-theme :type git :host github :repo "fake/fake"))
+              (straight-use-package '(yaicomplete :type git :host github :repo "fake/faker"))
+              (straight-use-package '(mew :type git :host gitlab :repo "fake/fakest" :no-build))))
+         (leaf-pre-init)
+         (leaf-init)))))
+#+end_src
+
 * Bind keywords
 ** :bind :bind* keywords
 These keywords are buildin. Info is [[https://github.com/conao3/leaf.el#bind-bind-keywords][here]].

--- a/README.org
+++ b/README.org
@@ -1310,6 +1310,7 @@ Note: ~macrostep~ return ~function~ instead of #', replace it via follow regexp 
 - Naoya Yamashita ([[https://github.com/conao3][conao3]])
 
 ** Contributors
+- Leo Gaskin ([[https://github.com/leotaku][leotaku]])
 
 ** Special Thanks
 Advice and comments given by [[http://emacs-jp.github.io/][Emacs-JP]]'s forum member has been a great help

--- a/leaf-keywords-tests.el
+++ b/leaf-keywords-tests.el
@@ -332,6 +332,84 @@ Example
        (leaf-pre-init)
        (leaf-init)))))
 
+(cort-deftest-with-macroexpand leaf/straight
+  '(((leaf leaf
+       :init (leaf-pre-init)
+       :straight t
+       :config (leaf-init))
+     (prog1 'leaf
+       (eval-after-load 'straight
+         '(progn
+            (straight-use-package 'leaf)))
+       (leaf-pre-init)
+       (leaf-init)))
+
+    ((leaf leaf
+       :init (leaf-pre-init)
+       :straight leaf leaf-polyfill
+       :config (leaf-init))
+     (prog1 'leaf
+       (eval-after-load 'straight
+         '(progn
+            (straight-use-package 'leaf)
+            (straight-use-package 'leaf-polyfill)))
+       (leaf-pre-init)
+       (leaf-init)))
+
+    ((leaf leaf
+       :init (leaf-pre-init)
+       :straight t
+       :straight leaf-polyfill
+       :config (leaf-init))
+     (prog1 'leaf
+       (eval-after-load 'straight
+         '(progn
+            (straight-use-package 'leaf)
+            (straight-use-package 'leaf-polyfill)))
+       (leaf-pre-init)
+       (leaf-init)))
+
+    ((leaf leaf
+       :init (leaf-pre-init)
+       :straight t leaf-polyfill
+       :config (leaf-init))
+     (prog1 'leaf
+       (eval-after-load 'straight
+         '(progn
+            (straight-use-package 'leaf)
+            (straight-use-package 'leaf-polyfill)))
+       (leaf-pre-init)
+       (leaf-init)))
+
+    ((leaf leaf
+       :init (leaf-pre-init)
+       :straight (zenburn-theme :type git :host github
+                                :repo "fake/fake")
+       :config (leaf-init))
+     (prog1 'leaf
+       (eval-after-load 'straight
+         '(progn
+            (straight-use-package '(zenburn-theme :type git :host github
+                                                  :repo "fake/fake"))))
+       (leaf-pre-init)
+       (leaf-init)))
+
+    ((leaf leaf
+       :init (leaf-pre-init)
+       :straight
+       (zenburn-theme :type git :host github :repo "fake/fake")
+       (yaicomplete :type git :host github :repo "fake/faker")
+       (mew :type git :host gitlab :repo "fake/fakest" :no-build)
+       :config (leaf-init))
+     (prog1 'leaf
+       (eval-after-load 'straight
+         '(progn
+            (straight-use-package '(zenburn-theme :type git :host github :repo "fake/fake"))
+            (straight-use-package '(yaicomplete :type git :host github :repo "fake/faker"))
+            (straight-use-package '(mew :type git :host gitlab :repo "fake/fakest" :no-build))))
+       (leaf-pre-init)
+       (leaf-init)))))
+
 (cort-deftest-with-macroexpand leaf/key-combo
   '(((leaf key-combo
        :combo (("="   . (" = " " == " " === " ))

--- a/leaf-keywords-tests.el
+++ b/leaf-keywords-tests.el
@@ -383,14 +383,12 @@ Example
 
     ((leaf leaf
        :init (leaf-pre-init)
-       :straight (zenburn-theme :type git :host github
-                                :repo "fake/fake")
+       :straight (zenburn-theme :type git :host github :repo "fake/fake")
        :config (leaf-init))
      (prog1 'leaf
        (eval-after-load 'straight
          '(progn
-            (straight-use-package '(zenburn-theme :type git :host github
-                                                  :repo "fake/fake"))))
+            (straight-use-package '(zenburn-theme :type git :host github :repo "fake/fake"))))
        (leaf-pre-init)
        (leaf-init)))
 

--- a/leaf-keywords.el
+++ b/leaf-keywords.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 1.1.5
+;; Version: 1.1.6
 ;; URL: https://github.com/conao3/leaf-keywords.el
 ;; Package-Requires: ((emacs "24.4") (leaf "3.1.0"))
 

--- a/leaf-keywords.el
+++ b/leaf-keywords.el
@@ -109,6 +109,9 @@
 (defcustom leaf-keywords-after-conditions
   (cdr
    '(:dummy
+     :straight `((eval-after-load 'straight
+                   '(progn ,@(mapcar (lambda (elm) `(straight-use-package ',elm)) leaf--value)))
+                 ,@leaf--body)
      :el-get `((eval-after-load 'el-get
                  '(progn ,@(mapcar (lambda (elm) `(el-get-bundle ,@elm)) leaf--value)))
                ,@leaf--body)))
@@ -327,6 +330,12 @@
      (mapcar
       (lambda (elm)
         (leaf-normalize-list-in-list (if (eq t elm) leaf--name elm) 'allow-dotlist))
+      leaf--value))
+    
+    ((memq leaf--key '(:straight))
+     (mapcar
+      (lambda (elm)
+        (if (eq t elm) leaf--name elm))
       leaf--value)))
   "Additional `leaf-normalize'."
   :set #'leaf-keywords-set-normalize


### PR DESCRIPTION
This has been discussed in #33 

Are the `README` entries generated, or should I just manually copy the `cort-deftest`s into the file?