### PR TITLE
define-transient-command -> transient-define-prefix

### DIFF
--- a/README.org
+++ b/README.org
@@ -717,7 +717,7 @@ If you pass a list, you pass it to ~define-transient-command~, and if you pass a
             ("!" "Run" dired-git-run)]]))
 
        (prog1 'dired-git
-         (define-transient-command transient-dwim-dired-mode--git ()
+         (transient-define-prefix transient-dwim-dired-mode--git ()
            "Transient-dwim for `dired-mode--git'."
            [["Worktree"
              ("c" "Commit" dired-git-commit)

--- a/README.org
+++ b/README.org
@@ -1928,6 +1928,7 @@ Note: ~macrostep~ return ~function~ instead of #', replace it via follow regexp 
 
 ** Contributors
 - Leo Gaskin ([[https://github.com/leotaku][leotaku]])
+- Nasy ([[https://github.com/nasyxx][Nasy]])
 
 ** Special Thanks
 Advice and comments given by [[http://emacs-jp.github.io/][Emacs-JP]]'s forum member has been a great help

--- a/leaf-keywords-tests.el
+++ b/leaf-keywords-tests.el
@@ -1361,7 +1361,7 @@ Example
           ("!" "Run" dired-git-run)]]))
 
      (prog1 'dired-git
-       (define-transient-command transient-dwim-dired-mode--git ()
+       (transient-define-prefix transient-dwim-dired-mode--git ()
          "Transient-dwim for `dired-mode--git'."
          [["Worktree"
            ("c" "Commit" dired-git-commit)

--- a/leaf-keywords.el
+++ b/leaf-keywords.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Maintainer: Naoya Yamashita <conao3@gmail.com>
 ;; Keywords: lisp settings
-;; Version: 1.5.0
+;; Version: 1.5.1
 ;; URL: https://github.com/conao3/leaf-keywords.el
 ;; Package-Requires: ((emacs "24.4") (leaf "3.5.0"))
 

--- a/leaf-keywords.el
+++ b/leaf-keywords.el
@@ -120,7 +120,7 @@
                  `(,@(mapcar (lambda (elm) `(defhydra ,@elm)) (car leaf--value)) ,@leaf--body))
    :transient  (progn
                  ;; (leaf-register-autoload (cadr leaf--value) leaf--name)
-                 `(,@(mapcar (lambda (elm) `(define-transient-command ,@elm)) (car leaf--value)) ,@leaf--body))
+                 `(,@(mapcar (lambda (elm) `(transient-define-prefix ,@elm)) (car leaf--value)) ,@leaf--body))
    :combo      (progn
                  (leaf-register-autoload (cadr leaf--value) leaf--name)
                  `(,@(mapcar (lambda (elm) `(key-combo-define ,@elm)) (car leaf--value)) ,@leaf--body))


### PR DESCRIPTION
`define-transient-command` is an obsolete alias (as of Transient 0.3.0);

Use `transient-define-prefix` instead of `define-transient-command`