### PR TITLE
Allows already installed packages to be loaded with the :feather keyword.

### DIFF
--- a/leaf-keywords-tests.el
+++ b/leaf-keywords-tests.el
@@ -303,9 +303,10 @@ Example
        :config (leaf-init))
      (prog1 'leaf
        (leaf-handler-package leaf leaf nil)
-       (feather-add-after-installed-hook-sexp leaf
-         (leaf-pre-init)
-         (leaf-init))))
+       (eval
+	(feather-add-after-installed-hook-sexp leaf
+          (leaf-pre-init)
+          (leaf-init)))))
 
     ;; multi symbols will be accepted
     ((leaf leaf
@@ -315,9 +316,10 @@ Example
      (prog1 'leaf
        (leaf-handler-package leaf leaf nil)
        (leaf-handler-package leaf leaf-polyfill nil)
-       (feather-add-after-installed-hook-sexp leaf-polyfill
-         (leaf-pre-init)
-         (leaf-init))))
+       (eval
+	(feather-add-after-installed-hook-sexp leaf-polyfill
+          (leaf-pre-init)
+          (leaf-init)))))
 
     ;; multi symbols in list will be accepted
     ((leaf leaf
@@ -327,8 +329,9 @@ Example
        (leaf-handler-package leaf feather nil)
        (leaf-handler-package leaf leaf-key nil)
        (leaf-handler-package leaf leaf-browser nil)
-       (feather-add-after-installed-hook-sexp leaf-browser
-         (leaf-init))))
+       (eval
+	(feather-add-after-installed-hook-sexp leaf-browser
+          (leaf-init)))))
 
     ;; multi keyword will be accepted
     ((leaf leaf
@@ -339,9 +342,10 @@ Example
      (prog1 'leaf
        (leaf-handler-package leaf leaf nil)
        (leaf-handler-package leaf leaf-polyfill nil)
-       (feather-add-after-installed-hook-sexp leaf-polyfill
-         (leaf-pre-init)
-         (leaf-init))))
+       (eval
+	(feather-add-after-installed-hook-sexp leaf-polyfill
+          (leaf-pre-init)
+          (leaf-init)))))
 
     ;; keywords such as :preface that expand before :feather
     ;; are not registered in the hook of feather
@@ -353,9 +357,10 @@ Example
      (prog1 'leaf
        (leaf-preface)
        (leaf-handler-package leaf leaf nil)
-       (feather-add-after-installed-hook-sexp leaf
-         (leaf-pre-init)
-         (leaf-init))))))
+       (eval
+	(feather-add-after-installed-hook-sexp leaf
+          (leaf-pre-init)
+          (leaf-init)))))))
 
 (cort-deftest-with-macroexpand leaf/el-get
   '(((leaf leaf

--- a/leaf-keywords.el
+++ b/leaf-keywords.el
@@ -101,7 +101,7 @@
 (defcustom leaf-keywords-after-conditions
   (leaf-list
    :feather    `(,@(mapcar (lambda (elm) `(leaf-handler-package ,leaf--name ,(car elm) ,(cdr elm))) leaf--value)
-                 (feather-add-after-installed-hook-sexp ,(caar (last leaf--value)) ,@leaf--body))
+                 (eval (feather-add-after-installed-hook-sexp ,(caar (last leaf--value)) ,@leaf--body)))
    :straight   `(,@(mapcar (lambda (elm) `(straight-use-package ',elm)) leaf--value) ,@leaf--body)
    :el-get     `(,@(mapcar (lambda (elm) `(el-get-bundle ,@elm)) leaf--value) ,@leaf--body)
    :ensure-system-package


### PR DESCRIPTION
With this, the list created by the `feather-add-after-installed-hook-sexp` macro is evaluated and packages that contain a `:feather` keyword, and that are already installed, are loaded as they should. 
This change solves the conao3/feather.el#11.