### PR TITLE
chore: modernize leaf dependency requirement

### DIFF
--- a/leaf-keywords.el
+++ b/leaf-keywords.el
@@ -7,7 +7,7 @@
 ;; Keywords: lisp settings
 ;; Version: 2.0.8
 ;; URL: https://github.com/conao3/leaf-keywords.el
-;; Package-Requires: ((emacs "24.4") (leaf "3.5.0"))
+;; Package-Requires: ((emacs "24.4") (leaf "4.5.5"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Summary

Modernizes the project's dependency declarations to their latest versions.

- Bumped `Package-Requires` from `(leaf "3.5.0")` to `(leaf "4.5.5")` — a major bump from leaf 3.x to 4.x, matching the version currently declared by leaf.el's master HEAD that the test pipeline already builds against.

### Notes

- The only external dependency is `leaf.el`. The Makefile pins `LEAF_REF` to `1e363fe...`, which is **already** leaf.el's latest `master` HEAD (the "lockfile" equivalent), so no lockfile change was required — it is already current.
- The `(emacs "24.4")` minimum was intentionally left unchanged: the CI matrix explicitly tests Emacs 24.4–27.1, and leaf.el itself only requires Emacs 24.1, so there is no dependency-driven reason to raise it and doing so would break the existing CI matrix.

## Test plan

- [x] `make clean && make test` — fresh leaf.el fetch from master, all 126 tests pass on Emacs 29.3
- [ ] CI matrix (Emacs 24.4 → snapshot) green on the PR

https://claude.ai/code/session_01TBHU9uBZ3fhsG9eSkEoP29

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBHU9uBZ3fhsG9eSkEoP29)_